### PR TITLE
feat!: convert to ESM and restrict the published tarball

### DIFF
--- a/dist/check-i18n-variables.js
+++ b/dist/check-i18n-variables.js
@@ -3,16 +3,13 @@
 // Checks all locize keys (in the codebase) with known variables against key
 // values in locize ensuring that variables in locize refer to known vars.
 //
-const i18next = require('i18next')
-const ICU = require('i18next-icu')
-const HttpBackend = require('i18next-http-backend')
-const {IntlMessageFormat} = require('intl-messageformat')
+import HttpBackend from 'i18next-http-backend'
+import ICU from 'i18next-icu'
+import i18next from 'i18next'
+import {IntlMessageFormat} from 'intl-messageformat'
 
-const {
-  extractTranslationKeysAndVariables,
-  KNOWN_VARIABLES_TAG
-} = require('./translation-extraction.js')
-const {getFiles, filterJsFiles, supportedLngs} = require('./helpers.js')
+import {getFiles, filterJsFiles, supportedLngs} from './helpers.js'
+import {extractTranslationKeysAndVariables, KNOWN_VARIABLES_TAG} from './translation-extraction.js'
 
 const [_nodeBin, _scriptPath, ...projects] = process.argv
 

--- a/dist/check-i18next-icu-parser.js
+++ b/dist/check-i18next-icu-parser.js
@@ -2,10 +2,11 @@
 //
 // Checks all keys in Locize to make sure that they can be parsed by the `i18next` `t` function
 //
-const i18next = require('i18next')
-const ICU = require('i18next-icu')
-const HttpBackend = require('i18next-http-backend')
-const {supportedLngs} = require('./helpers.js')
+import HttpBackend from 'i18next-http-backend'
+import ICU from 'i18next-icu'
+import i18next from 'i18next'
+
+import {supportedLngs} from './helpers.js'
 
 const VALID_NAMESPACES = ['school', 'student', 'console', 'classroom', 'common']
 

--- a/dist/helpers.js
+++ b/dist/helpers.js
@@ -1,9 +1,8 @@
-#!/usr/bin/env node
-const {promises: fs} = require('fs')
-const p = require('path')
+import {promises as fs} from 'node:fs'
+import p from 'node:path'
 
 // Modified from https://dev.to/leonard/get-files-recursive-with-the-node-js-file-system-fs-2n7o
-async function getFiles(path) {
+export async function getFiles(path) {
   const allEntries = await fs.readdir(path, {withFileTypes: true})
 
   const entries = allEntries.filter(file => file.name !== 'node_modules' && file.name !== '.cache')
@@ -21,14 +20,8 @@ async function getFiles(path) {
   return files
 }
 
-module.exports.getFiles = getFiles
-
-const filterJsFiles = f =>
+export const filterJsFiles = f =>
   (f.name.endsWith('.js') || f.name.endsWith('.ts') || f.name.endsWith('.tsx')) &&
   !f.name.endsWith('min.js')
 
-module.exports.filterJsFiles = filterJsFiles
-
-const supportedLngs = ['es', 'en', 'en-GB']
-
-module.exports.supportedLngs = supportedLngs
+export const supportedLngs = ['es', 'en', 'en-GB']

--- a/dist/translation-extraction.js
+++ b/dist/translation-extraction.js
@@ -1,6 +1,6 @@
-const fs = require('fs')
-const parser = require('flow-parser')
-const walk = require('esprima-walk')
+import fs from 'node:fs'
+import parser from 'flow-parser'
+import walk from 'esprima-walk'
 
 const isIdentifierT = node => node && node.type === 'Identifier' && node.name === 't'
 
@@ -24,8 +24,8 @@ const isObjectWithSimpleProperties = node =>
   node.type === 'ObjectExpression' &&
   node.properties.every(p => p.type === 'Property' && p.key.type === 'Identifier')
 
-const KNOWN_VARIABLES_TAG = 'i18n-key-with-known-variables'
-const UNKNOWN_VARIABLES_TAG = 'i18n-key-with-unknown-variables'
+export const KNOWN_VARIABLES_TAG = 'i18n-key-with-known-variables'
+export const UNKNOWN_VARIABLES_TAG = 'i18n-key-with-unknown-variables'
 
 const knownVariables = (source, i18nKey, objectWithSimpleProperties) => ({
   tag: KNOWN_VARIABLES_TAG,
@@ -47,9 +47,6 @@ const unknownVariables = (source, i18nKey) => ({
   i18nKey
 })
 
-module.exports.KNOWN_VARIABLES_TAG = KNOWN_VARIABLES_TAG
-module.exports.UNKNOWN_VARIABLES_TAG = UNKNOWN_VARIABLES_TAG
-
 // Attempt to find all translations keys and their provided variables in use in JS files.
 //
 // Methodology:
@@ -67,7 +64,7 @@ module.exports.UNKNOWN_VARIABLES_TAG = UNKNOWN_VARIABLES_TAG
 //       are not known
 //
 // Yields keys with variables as encountered without sorting or de-duplication.
-module.exports.extractTranslationKeysAndVariables = path => {
+export const extractTranslationKeysAndVariables = path => {
   const content = fs.readFileSync(path, {encoding: 'utf8'})
   const ast = parser.parse(content)
 

--- a/dist/translation-keys.js
+++ b/dist/translation-keys.js
@@ -11,8 +11,9 @@
 //
 // We stream out the keys as seen. We do no sorting or de-duplication.
 //
-const {extractTranslationKeysAndVariables} = require('./translation-extraction.js')
-const readline = require('readline')
+import readline from 'node:readline'
+
+import {extractTranslationKeysAndVariables} from './translation-extraction.js'
 
 const lines = readline.createInterface({
   input: process.stdin,

--- a/package.json
+++ b/package.json
@@ -4,12 +4,15 @@
   "description": "Scripts for i18n",
   "author": "Renaissance Learning Inc",
   "license": "MIT",
+  "type": "module",
   "bin": {
     "check-i18n-variables": "./dist/check-i18n-variables.js",
     "check-i18next-icu-parser": "./dist/check-i18next-icu-parser.js",
     "check-missing-translations": "./dist/check-missing-translations"
   },
-  "main": "./dist/index.js",
+  "files": [
+    "dist"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freckle/i18n-scripts-js.git"

--- a/src/check-i18n-variables.js
+++ b/src/check-i18n-variables.js
@@ -3,16 +3,13 @@
 // Checks all locize keys (in the codebase) with known variables against key
 // values in locize ensuring that variables in locize refer to known vars.
 //
-const i18next = require('i18next')
-const ICU = require('i18next-icu')
-const HttpBackend = require('i18next-http-backend')
-const {IntlMessageFormat} = require('intl-messageformat')
+import HttpBackend from 'i18next-http-backend'
+import ICU from 'i18next-icu'
+import i18next from 'i18next'
+import {IntlMessageFormat} from 'intl-messageformat'
 
-const {
-  extractTranslationKeysAndVariables,
-  KNOWN_VARIABLES_TAG
-} = require('./translation-extraction.js')
-const {getFiles, filterJsFiles, supportedLngs} = require('./helpers.js')
+import {getFiles, filterJsFiles, supportedLngs} from './helpers.js'
+import {extractTranslationKeysAndVariables, KNOWN_VARIABLES_TAG} from './translation-extraction.js'
 
 const [_nodeBin, _scriptPath, ...projects] = process.argv
 

--- a/src/check-i18next-icu-parser.js
+++ b/src/check-i18next-icu-parser.js
@@ -2,10 +2,11 @@
 //
 // Checks all keys in Locize to make sure that they can be parsed by the `i18next` `t` function
 //
-const i18next = require('i18next')
-const ICU = require('i18next-icu')
-const HttpBackend = require('i18next-http-backend')
-const {supportedLngs} = require('./helpers.js')
+import HttpBackend from 'i18next-http-backend'
+import ICU from 'i18next-icu'
+import i18next from 'i18next'
+
+import {supportedLngs} from './helpers.js'
 
 const VALID_NAMESPACES = ['school', 'student', 'console', 'classroom', 'common']
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,9 +1,8 @@
-#!/usr/bin/env node
-const {promises: fs} = require('fs')
-const p = require('path')
+import {promises as fs} from 'node:fs'
+import p from 'node:path'
 
 // Modified from https://dev.to/leonard/get-files-recursive-with-the-node-js-file-system-fs-2n7o
-async function getFiles(path) {
+export async function getFiles(path) {
   const allEntries = await fs.readdir(path, {withFileTypes: true})
 
   const entries = allEntries.filter(file => file.name !== 'node_modules' && file.name !== '.cache')
@@ -21,14 +20,8 @@ async function getFiles(path) {
   return files
 }
 
-module.exports.getFiles = getFiles
-
-const filterJsFiles = f =>
+export const filterJsFiles = f =>
   (f.name.endsWith('.js') || f.name.endsWith('.ts') || f.name.endsWith('.tsx')) &&
   !f.name.endsWith('min.js')
 
-module.exports.filterJsFiles = filterJsFiles
-
-const supportedLngs = ['es', 'en', 'en-GB']
-
-module.exports.supportedLngs = supportedLngs
+export const supportedLngs = ['es', 'en', 'en-GB']

--- a/src/translation-extraction.js
+++ b/src/translation-extraction.js
@@ -1,6 +1,6 @@
-const fs = require('fs')
-const parser = require('flow-parser')
-const walk = require('esprima-walk')
+import fs from 'node:fs'
+import parser from 'flow-parser'
+import walk from 'esprima-walk'
 
 const isIdentifierT = node => node && node.type === 'Identifier' && node.name === 't'
 
@@ -24,8 +24,8 @@ const isObjectWithSimpleProperties = node =>
   node.type === 'ObjectExpression' &&
   node.properties.every(p => p.type === 'Property' && p.key.type === 'Identifier')
 
-const KNOWN_VARIABLES_TAG = 'i18n-key-with-known-variables'
-const UNKNOWN_VARIABLES_TAG = 'i18n-key-with-unknown-variables'
+export const KNOWN_VARIABLES_TAG = 'i18n-key-with-known-variables'
+export const UNKNOWN_VARIABLES_TAG = 'i18n-key-with-unknown-variables'
 
 const knownVariables = (source, i18nKey, objectWithSimpleProperties) => ({
   tag: KNOWN_VARIABLES_TAG,
@@ -47,9 +47,6 @@ const unknownVariables = (source, i18nKey) => ({
   i18nKey
 })
 
-module.exports.KNOWN_VARIABLES_TAG = KNOWN_VARIABLES_TAG
-module.exports.UNKNOWN_VARIABLES_TAG = UNKNOWN_VARIABLES_TAG
-
 // Attempt to find all translations keys and their provided variables in use in JS files.
 //
 // Methodology:
@@ -67,7 +64,7 @@ module.exports.UNKNOWN_VARIABLES_TAG = UNKNOWN_VARIABLES_TAG
 //       are not known
 //
 // Yields keys with variables as encountered without sorting or de-duplication.
-module.exports.extractTranslationKeysAndVariables = path => {
+export const extractTranslationKeysAndVariables = path => {
   const content = fs.readFileSync(path, {encoding: 'utf8'})
   const ast = parser.parse(content)
 

--- a/src/translation-keys.js
+++ b/src/translation-keys.js
@@ -11,8 +11,9 @@
 //
 // We stream out the keys as seen. We do no sorting or de-duplication.
 //
-const {extractTranslationKeysAndVariables} = require('./translation-extraction.js')
-const readline = require('readline')
+import readline from 'node:readline'
+
+import {extractTranslationKeysAndVariables} from './translation-extraction.js'
 
 const lines = readline.createInterface({
   input: process.stdin,


### PR DESCRIPTION
## Summary

The breaking change: this package becomes ESM, and the published tarball is restricted to `dist/`.

Stacked on [#96](https://github.com/freckle/i18n-scripts-js/pull/96). Carries `feat!` and `BREAKING CHANGE:` footers so semantic-release cuts a major.

## ESM

`"type": "module"`, and the five sources converted from `require`/`module.exports` to `import`/`export`. Node built-ins are imported under the `node:` prefix (`node:fs`, `node:path`, `node:readline`).

`src/helpers.js` loses a `#!/usr/bin/env node` shebang it never needed. It is an imported module, not a script.

The two edits that would otherwise have made this conversion illegal are already done, in [#96](https://github.com/freckle/i18n-scripts-js/pull/96):

- a top-level `return` in `check-i18n-variables.js`, a syntax error in a module
- a variable named `interface` in `translation-keys.js`, a reserved word in strict mode

Both were **eslint errors in that PR regardless of ESM** — ESLint's flat config parses `.js` as `sourceType: 'module'` whatever `package.json`'s `type` says — so they belong there, and this diff is left as a mechanical `require` → `import` conversion with no behavior change and no logic edits.

## Published tarball

Adds `"files": ["dist"]` and removes `"main"`.

`main` pointed at `./dist/index.js`, which has never existed in this package. There is no library entry point, only bins, so the field is removed rather than repaired.

`npm pack` contents, sorted:

```console
# main — 34 entries
package/.github/CODEOWNERS
package/.github/commenter.yml
package/.github/workflows/checklist.yml
package/.github/workflows/ci.yml
package/.github/workflows/mergeabot.yml
package/.github/workflows/release.yml
package/.prettierrc
package/.releaserc.yaml
package/.restyled.yaml
package/.yarn/releases/yarn-4.18.0.cjs
package/.yarnrc.yml
package/dist/…            (9 files)
package/LICENSE
package/package.json
package/README.md
package/RELEASE.md
package/renovate.json
package/src/…             (9 files)

# this branch — 9 entries
package/dist/check-i18n-variables.js
package/dist/check-i18next-icu-parser.js
package/dist/check-missing-translations
package/dist/helpers.js
package/dist/translation-extraction.js
package/dist/translation-keys.js
package/LICENSE
package/package.json
package/README.md
```

`src/`, the workflow files, `renovate.json`, `RELEASE.md` and the yarn release binary all stop shipping.

## Breaking changes

- **The package is ESM.** `require('@freckle/i18n-scripts/...')` no longer works. In practice nothing should be doing that — there is no `main` to require and, after this PR, nothing but `dist/` in the tarball — but it is a hard break for any consumer reaching into a path.
- **The tarball contains only `dist/`, `LICENSE`, `package.json` and `README.md`.** Any consumer resolving a `src/` path breaks.
- **`main` is removed.**

Two more breaking changes reach the same major from [#96](https://github.com/freckle/i18n-scripts-js/pull/96): the bins now propagate exit codes, and `dist/translation-keys` is now `dist/translation-keys.js`.

## Deliberately not in this PR

Tests, the coverage gate and knip: [#98](https://github.com/freckle/i18n-scripts-js/pull/98). The ESM switch does not depend on them, and they do not depend on it beyond import syntax.

## Verification

Clean `node_modules`, then the exact sequence this PR's `ci.yml` runs, on Node 24:

```console
$ rm -rf node_modules
$ pnpm install --frozen-lockfile     # exit 0
$ pnpm format-check                  # exit 0
$ pnpm lint                          # exit 0
$ pnpm build                         # exit 0
$ git status --porcelain              # empty, so check-git-clean-action passes
```

All three bins still run from the built `dist/` after the conversion:

```console
$ ./dist/check-i18n-variables.js
Usage: check-i18n-variables <path>
$ echo $?
64
$ ./dist/check-missing-translations
Usage: check-missing-translations namespace [project/path]
$ echo $?
64
$ echo sample.jsx | ./dist/translation-keys.js
HELLO
$ echo $?
0
```

`check-i18next-icu-parser` needs Locize, so only its argument validation is verifiable locally.

`pnpm-lock.yaml` is unchanged — this PR adds no dependency.

## Stack

1. [#90](https://github.com/freckle/i18n-scripts-js/pull/90) — pnpm, Node pin, ESLint, Prettier `format-check`
2. [#96](https://github.com/freckle/i18n-scripts-js/pull/96) — de-shim the bins, propagate exit codes (`fix!`)
3. **#97 — this PR**, ESM and the published tarball (`feat!`)
4. [#98](https://github.com/freckle/i18n-scripts-js/pull/98) — vitest, tests, coverage gate, knip
